### PR TITLE
Fixed icon memory leak issue

### DIFF
--- a/src/infi/systray/win32_adapter.py
+++ b/src/infi/systray/win32_adapter.py
@@ -27,6 +27,7 @@ GetSysColorBrush = ctypes.windll.user32.GetSysColorBrush
 FillRect = ctypes.windll.user32.FillRect
 DrawIconEx = ctypes.windll.user32.DrawIconEx
 SelectObject = ctypes.windll.gdi32.SelectObject
+DeleteObject = ctypes.windll.gdi32.DeleteObject
 DeleteDC = ctypes.windll.gdi32.DeleteDC
 DestroyWindow = ctypes.windll.user32.DestroyWindow
 GetModuleHandle = ctypes.windll.kernel32.GetModuleHandleA


### PR DESCRIPTION
Fixed icon memory leak by keeping a list of handles to the bitmap objects as they are created. Bitmaps are removed when the menu changes by calling DeleteObject on the handles in the list and then clearing the list.

There is no need to keep a collection of menus/submenus because [**DestroyMenu** is recursive, that is, it will destroy the menu and all its submenus.](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-destroymenu).